### PR TITLE
Simplify deploy and cleanup scripts

### DIFF
--- a/scripts/cleanup-stack.sh
+++ b/scripts/cleanup-stack.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
-STATE_FILE="$ROOT_DIR/scripts/.state/deploy-state.json"
 TERRAFORM_DIR="$ROOT_DIR/terraform"
 OIDC_APP_DIR="$ROOT_DIR/payment-app-by-oidc"
 FACTORS_APP_DIR="$ROOT_DIR/payment-app-by-factors-api"
@@ -14,57 +13,30 @@ require() {
   fi
 }
 
-require pnpm
-require terraform
-require jq
-require python3
-
-if [ ! -f "$STATE_FILE" ]; then
-  echo "State file $STATE_FILE not found. Nothing to cleanup?" >&2
-  exit 1
-fi
-
-STATE_JSON=$(cat "$STATE_FILE")
-
-get_state_value() {
-  local query=$1
-  echo "$STATE_JSON" | jq -er "$query"
+ensure_prereqs() {
+  require pnpm
+  require terraform
+  require awk
 }
 
-set_kv_binding_id() {
+read_kv_binding_id() {
   local app_dir=$1
-  local new_id=$2
   local config="$app_dir/wrangler.toml"
-  python3 - "$config" "$new_id" <<'PY'
-import sys
-path, new_id = sys.argv[1], sys.argv[2]
-with open(path, 'r', encoding='utf-8') as f:
-    lines = f.read().splitlines()
-
-in_kv = False
-target = False
-replaced = False
-
-for i, line in enumerate(lines):
-    stripped = line.strip()
-    if stripped.startswith('[['):
-        in_kv = stripped.startswith('[[kv_namespaces]]')
-        target = False
-    if in_kv and stripped.startswith('binding') and 'PAYMENT_STORE' in stripped:
-        target = True
-    if in_kv and target and stripped.startswith('id'):
-        indent = line[:len(line) - len(line.lstrip())]
-        lines[i] = f'{indent}id = "{new_id}"'
-        replaced = True
-        break
-
-if not replaced:
-    print('Failed to find PAYMENT_STORE KV binding in wrangler.toml', file=sys.stderr)
-    sys.exit(1)
-
-with open(path, 'w', encoding='utf-8') as f:
-    f.write('\n'.join(lines) + '\n')
-PY
+  awk '
+    BEGIN { in_kv = 0; target = 0 }
+    /^\[\[/ {
+      in_kv = ($0 ~ /^\[\[kv_namespaces\]\]/)
+      target = 0
+    }
+    in_kv && $0 ~ /^[[:space:]]*binding[[:space:]]*=[[:space:]]*"PAYMENT_STORE"/ { target = 1 }
+    in_kv && target && $0 ~ /^[[:space:]]*id[[:space:]]*=/ {
+      line = $0
+      gsub(/^[[:space:]]*id[[:space:]]*=[[:space:]]*"/, "", line)
+      gsub(/"[[:space:]]*$/, "", line)
+      print line
+      exit
+    }
+  ' "$config"
 }
 
 delete_secret() {
@@ -86,52 +58,49 @@ delete_worker() {
   fi
 }
 
-delete_kv_namespace() {
+delete_kv_namespace_if_configured() {
   local app_dir=$1
-  local namespace_id=$2
-  if (cd "$app_dir" && pnpm exec wrangler kv namespace delete --namespace-id "$namespace_id" -y --config wrangler.toml); then
-    echo "Deleted KV namespace $namespace_id"
+  local id
+  id=$(read_kv_binding_id "$app_dir")
+
+  if [ -z "$id" ] || [ "$id" = "your-kv-namespace-id" ]; then
+    echo "PAYMENT_STORE KV id is not configured in $(basename "$app_dir")/wrangler.toml, skipping KV delete."
+    return
+  fi
+
+  if (cd "$app_dir" && pnpm exec wrangler kv namespace delete --namespace-id "$id" -y --config wrangler.toml); then
+    echo "Deleted KV namespace $id for $(basename "$app_dir")"
   else
-    echo "Failed to delete KV namespace $namespace_id (maybe already gone)" >&2
+    echo "KV namespace $id may already be removed" >&2
   fi
 }
 
-terraform_auto_vars=$(get_state_value '.terraform_auto_vars')
+main() {
+  ensure_prereqs
 
-if [ -f "$terraform_auto_vars" ]; then
   echo "Destroying Terraform-managed resources..."
-  (cd "$TERRAFORM_DIR" && terraform destroy -auto-approve -input=false)
-else
-  echo "Terraform auto vars file $terraform_auto_vars not found. Skipping terraform destroy." >&2
-fi
+  (
+    cd "$TERRAFORM_DIR"
+    terraform init -input=false
+    terraform destroy -auto-approve -input=false
+  )
 
-if [ -f "$terraform_auto_vars" ]; then
-  rm -f "$terraform_auto_vars"
-fi
+  delete_secret "$OIDC_APP_DIR" OKTA_DOMAIN || true
+  delete_secret "$OIDC_APP_DIR" OKTA_CLIENT_ID || true
+  delete_secret "$OIDC_APP_DIR" OKTA_CLIENT_SECRET || true
 
-oidc_kv_id=$(get_state_value '.kv_namespaces["payment-app-by-oidc"].id')
-factors_kv_id=$(get_state_value '.kv_namespaces["payment-app-by-factors-api"].id')
-oidc_original_binding=$(echo "$STATE_JSON" | jq -r '(.wrangler_backup["payment-app-by-oidc"]) // "your-kv-namespace-id"')
-factors_original_binding=$(echo "$STATE_JSON" | jq -r '(.wrangler_backup["payment-app-by-factors-api"]) // "your-kv-namespace-id"')
+  delete_secret "$FACTORS_APP_DIR" OKTA_DOMAIN || true
+  delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_CLIENT_ID || true
+  delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_KID || true
+  delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_PRIVATE_KEY || true
 
-delete_secret "$OIDC_APP_DIR" OKTA_DOMAIN || true
-delete_secret "$OIDC_APP_DIR" OKTA_CLIENT_ID || true
-delete_secret "$OIDC_APP_DIR" OKTA_CLIENT_SECRET || true
+  delete_worker "$OIDC_APP_DIR" || true
+  delete_worker "$FACTORS_APP_DIR" || true
 
-delete_secret "$FACTORS_APP_DIR" OKTA_DOMAIN || true
-delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_CLIENT_ID || true
-delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_KID || true
-delete_secret "$FACTORS_APP_DIR" OKTA_MGMT_PRIVATE_KEY || true
+  delete_kv_namespace_if_configured "$OIDC_APP_DIR" || true
+  delete_kv_namespace_if_configured "$FACTORS_APP_DIR" || true
 
-delete_worker "$OIDC_APP_DIR" || true
-delete_worker "$FACTORS_APP_DIR" || true
+  echo "Cleanup complete."
+}
 
-delete_kv_namespace "$OIDC_APP_DIR" "$oidc_kv_id" || true
-delete_kv_namespace "$FACTORS_APP_DIR" "$factors_kv_id" || true
-
-set_kv_binding_id "$OIDC_APP_DIR" "$oidc_original_binding" >/dev/null
-set_kv_binding_id "$FACTORS_APP_DIR" "$factors_original_binding" >/dev/null
-
-rm -f "$STATE_FILE"
-
-echo "Cleanup complete."
+main "$@"

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -2,16 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
-STATE_DIR="$ROOT_DIR/scripts/.state"
-STATE_FILE="$STATE_DIR/deploy-state.json"
 TERRAFORM_DIR="$ROOT_DIR/terraform"
-TF_AUTO_VARS="$TERRAFORM_DIR/generated.auto.tfvars"
-
 OIDC_APP_DIR="$ROOT_DIR/payment-app-by-oidc"
 FACTORS_APP_DIR="$ROOT_DIR/payment-app-by-factors-api"
-STATE_WRITTEN=0
-OIDC_PREV_CFG=""
-FACTORS_PREV_CFG=""
 
 require() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -20,157 +13,92 @@ require() {
   fi
 }
 
-cleanup_on_exit() {
-  if [ "$STATE_WRITTEN" -eq 1 ]; then
-    return
-  fi
-  if [ -n "$OIDC_PREV_CFG" ]; then
-    set_kv_binding_id "$OIDC_APP_DIR" "$OIDC_PREV_CFG" >/dev/null 2>&1 || true
-  fi
-  if [ -n "$FACTORS_PREV_CFG" ]; then
-    set_kv_binding_id "$FACTORS_APP_DIR" "$FACTORS_PREV_CFG" >/dev/null 2>&1 || true
-  fi
-}
-
-trap cleanup_on_exit EXIT
-
 ensure_prereqs() {
   require pnpm
   require terraform
   require jq
-  require python3
-}
-
-ensure_clean_state() {
-  mkdir -p "$STATE_DIR"
-  if [ -f "$STATE_FILE" ]; then
-    echo "State file $STATE_FILE already exists. Run scripts/cleanup-stack.sh before deploying again." >&2
-    exit 1
-  fi
-}
-
-set_kv_binding_id() {
-  local app_dir=$1
-  local new_id=$2
-  local config="$app_dir/wrangler.toml"
-  python3 - "$config" "$new_id" <<'PY'
-import sys
-path, new_id = sys.argv[1], sys.argv[2]
-with open(path, 'r', encoding='utf-8') as f:
-    lines = f.read().splitlines()
-
-in_kv = False
-target = False
-prev_id = None
-replaced = False
-
-for i, line in enumerate(lines):
-    stripped = line.strip()
-    if stripped.startswith('[['):
-        in_kv = stripped.startswith('[[kv_namespaces]]')
-        target = False
-    if in_kv and stripped.startswith('binding') and 'PAYMENT_STORE' in stripped:
-        target = True
-    if in_kv and target and stripped.startswith('id'):
-        prev = stripped.split('=', 1)[1].strip().strip('"')
-        prev_id = prev if prev else ''
-        indent = line[:len(line) - len(line.lstrip())]
-        lines[i] = f'{indent}id = "{new_id}"'
-        replaced = True
-        break
-
-if not replaced:
-    print('Failed to find PAYMENT_STORE KV binding in wrangler.toml', file=sys.stderr)
-    sys.exit(1)
-
-with open(path, 'w', encoding='utf-8') as f:
-    f.write('\n'.join(lines) + '\n')
-
-print(prev_id or '')
-PY
+  require awk
 }
 
 install_dependencies() {
   local app_dir=$1
   if [ -f "$app_dir/package.json" ]; then
     echo "Installing dependencies in $app_dir..."
-    (cd "$app_dir" && pnpm install)
+    (cd "$app_dir" && pnpm install --frozen-lockfile)
   fi
 }
 
-get_worker_name() {
+read_kv_binding_id() {
   local app_dir=$1
-  local name_line
-  name_line=$(grep -E '^name\s*=\s*"' "$app_dir/wrangler.toml" | head -n1 || true)
-  if [ -z "$name_line" ]; then
-    echo "Unable to find worker name in $app_dir/wrangler.toml" >&2
-    exit 1
-  fi
-  echo "$name_line" | sed -E 's/name\s*=\s*"([^"]+)"/\1/'
+  local config="$app_dir/wrangler.toml"
+  awk '
+    BEGIN { in_kv = 0; target = 0 }
+    /^\[\[/ {
+      in_kv = ($0 ~ /^\[\[kv_namespaces\]\]/)
+      target = 0
+    }
+    in_kv && $0 ~ /^[[:space:]]*binding[[:space:]]*=[[:space:]]*"PAYMENT_STORE"/ { target = 1 }
+    in_kv && target && $0 ~ /^[[:space:]]*id[[:space:]]*=/ {
+      line = $0
+      gsub(/^[[:space:]]*id[[:space:]]*=[[:space:]]*"/, "", line)
+      gsub(/"[[:space:]]*$/, "", line)
+      print line
+      exit
+    }
+  ' "$config"
 }
 
-create_kv_namespace() {
+require_valid_kv_binding() {
   local app_dir=$1
-  local title=$2
-  echo "Creating KV namespace '$title' for $(basename "$app_dir")..."
-  local output
-  if ! output=$(cd "$app_dir" && pnpm exec wrangler kv namespace create "$title" --config wrangler.toml --json 2>&1); then
-    echo "$output" >&2
-    exit 1
-  fi
-  echo "$output"
   local id
-  id=$(echo "$output" | jq -r '.id // empty' 2>/dev/null)
-  if [ -z "$id" ]; then
-    echo "Failed to parse KV namespace ID from wrangler output." >&2
-    echo "$output" >&2
+  id=$(read_kv_binding_id "$app_dir")
+  if [ -z "$id" ] || [ "$id" = "your-kv-namespace-id" ]; then
+    echo "Error: PAYMENT_STORE KV binding id is not set in $app_dir/wrangler.toml" >&2
+    echo "Set a valid id first (wrangler.toml), then rerun this script." >&2
     exit 1
   fi
-  echo "$id"
+}
+
+extract_workers_url() {
+  sed -nE 's#.*(https://[[:alnum:]._-]+\.workers\.dev).*#\1#p' | head -n1
 }
 
 deploy_and_get_url() {
   local app_dir=$1
-  echo "Deploying $(basename "$app_dir") to capture Workers URL..."
   local output
-  if ! output=$(cd "$app_dir" && pnpm exec wrangler deploy 2>&1 | tee /dev/stderr); then
+
+  echo "Deploying $(basename "$app_dir")..."
+  if ! output=$(cd "$app_dir" && pnpm exec wrangler deploy 2>&1); then
+    printf '%s\n' "$output" >&2
     exit 1
   fi
+
+  printf '%s\n' "$output"
+
   local url
-  url=$(echo "$output" | python3 - <<'PY'
-import re, sys
-text = sys.stdin.read()
-match = re.search(r'https://[\w.-]+\.workers\.dev', text)
-print(match.group(0) if match else "")
-PY
-  )
+  url=$(printf '%s\n' "$output" | extract_workers_url)
   if [ -z "$url" ]; then
-    echo "Failed to detect workers.dev URL from deploy output." >&2
+    echo "Error: Failed to detect workers.dev URL from deploy output." >&2
     exit 1
   fi
-  echo "$url"
+
+  printf '%s\n' "$url"
 }
 
-write_tfvars() {
+run_terraform_apply() {
   local worker_url=$1
-  cat > "$TF_AUTO_VARS" <<TFVARS
-stepup_redirect_uris = [
-  "$worker_url/callback",
-  "$worker_url"
-]
-TFVARS
-}
-
-run_terraform() {
-  echo "Initializing Terraform..."
-  (cd "$TERRAFORM_DIR" && terraform init -input=false)
   echo "Applying Terraform changes..."
-  (cd "$TERRAFORM_DIR" && terraform apply -auto-approve -input=false)
+  (
+    cd "$TERRAFORM_DIR"
+    terraform init -input=false
+    terraform apply -auto-approve -input=false \
+      -var="stepup_redirect_uris=[\"$worker_url/callback\",\"$worker_url\"]"
+  )
 }
 
 read_tf_output() {
   local key=$1
-  echo "$TF_OUTPUTS" | jq -er ".[\"$key\"].value"
+  (cd "$TERRAFORM_DIR" && terraform output -json) | jq -er ".[\"$key\"].value"
 }
 
 put_secret() {
@@ -184,76 +112,21 @@ put_secret() {
   fi | (cd "$app_dir" && pnpm exec wrangler secret put "$key")
 }
 
-save_state() {
-  local oidc_kv_id=$1
-  local oidc_kv_title=$2
-  local oidc_url=$3
-  local factors_kv_id=$4
-  local factors_kv_title=$5
-  local factors_url=$6
-  local oidc_prev_id=$7
-  local factors_prev_id=$8
-  cat > "$STATE_FILE" <<STATE
-{
-  "kv_namespaces": {
-    "payment-app-by-oidc": {
-      "id": "$oidc_kv_id",
-      "title": "$oidc_kv_title"
-    },
-    "payment-app-by-factors-api": {
-      "id": "$factors_kv_id",
-      "title": "$factors_kv_title"
-    }
-  },
-  "workers": {
-    "payment-app-by-oidc": "$oidc_url",
-    "payment-app-by-factors-api": "$factors_url"
-  },
-  "terraform_auto_vars": "$TF_AUTO_VARS",
-  "wrangler_backup": {
-    "payment-app-by-oidc": "$oidc_prev_id",
-    "payment-app-by-factors-api": "$factors_prev_id"
-  }
-}
-STATE
-}
-
 main() {
   ensure_prereqs
-  ensure_clean_state
 
   install_dependencies "$OIDC_APP_DIR"
   install_dependencies "$FACTORS_APP_DIR"
 
-  local oidc_worker_name factors_worker_name
-  oidc_worker_name=$(get_worker_name "$OIDC_APP_DIR")
-  factors_worker_name=$(get_worker_name "$FACTORS_APP_DIR")
-
-  local timestamp=$(date +%s)
-  local oidc_kv_title="$oidc_worker_name-kv-$timestamp"
-  local factors_kv_title="$factors_worker_name-kv-$timestamp"
-
-  local oidc_kv_id factors_kv_id
-  oidc_kv_id=$(create_kv_namespace "$OIDC_APP_DIR" "$oidc_kv_title")
-  factors_kv_id=$(create_kv_namespace "$FACTORS_APP_DIR" "$factors_kv_title")
-
-  local oidc_prev_kv_id factors_prev_kv_id
-  oidc_prev_kv_id=$(set_kv_binding_id "$OIDC_APP_DIR" "$oidc_kv_id")
-  factors_prev_kv_id=$(set_kv_binding_id "$FACTORS_APP_DIR" "$factors_kv_id")
-  OIDC_PREV_CFG=$oidc_prev_kv_id
-  FACTORS_PREV_CFG=$factors_prev_kv_id
+  require_valid_kv_binding "$OIDC_APP_DIR"
+  require_valid_kv_binding "$FACTORS_APP_DIR"
 
   local oidc_worker_url
-  oidc_worker_url=$(deploy_and_get_url "$OIDC_APP_DIR")
+  oidc_worker_url=$(deploy_and_get_url "$OIDC_APP_DIR" | tail -n1)
 
-  echo "Writing Terraform variables with redirect URLs..."
-  write_tfvars "$oidc_worker_url"
-
-  run_terraform
+  run_terraform_apply "$oidc_worker_url"
 
   echo "Fetching Terraform outputs..."
-  TF_OUTPUTS=$(cd "$TERRAFORM_DIR" && terraform output -json)
-
   local okta_domain stepup_client_id stepup_client_secret factors_client_id okta_key_id okta_private_key
   okta_domain=$(read_tf_output okta_domain)
   stepup_client_id=$(read_tf_output stepup_client_id)
@@ -272,18 +145,15 @@ main() {
   put_secret "$FACTORS_APP_DIR" OKTA_MGMT_KID "$okta_key_id"
   put_secret "$FACTORS_APP_DIR" OKTA_MGMT_PRIVATE_KEY "$okta_private_key"
 
-  oidc_worker_url=$(deploy_and_get_url "$OIDC_APP_DIR")
   local factors_worker_url
-  factors_worker_url=$(deploy_and_get_url "$FACTORS_APP_DIR")
+  factors_worker_url=$(deploy_and_get_url "$FACTORS_APP_DIR" | tail -n1)
 
-  save_state "$oidc_kv_id" "$oidc_kv_title" "$oidc_worker_url" "$factors_kv_id" "$factors_kv_title" "$factors_worker_url" "$oidc_prev_kv_id" "$factors_prev_kv_id"
-  STATE_WRITTEN=1
-
-  cat <<'SUMMARY'
+  cat <<SUMMARY
 
 Deployment complete!
-- Terraform config stored in generated.auto.tfvars
-- State stored in scripts/.state/deploy-state.json
+- OIDC Worker: $oidc_worker_url
+- Factors Worker: $factors_worker_url
+- No state/temp file was generated by this script.
 SUMMARY
 }
 


### PR DESCRIPTION
### Motivation
- Replace the previous deploy flow that created persistent temp/state files and edited `wrangler.toml` with a one-shot, stateless flow to avoid leftover artifacts.
- Remove the broken assumption that `wrangler kv namespace create` can emit JSON for easy parsing, since that prevented the original script from working.
- Avoid programmatic modification of `wrangler.toml` in favor of treating it as read-only and letting `wrangler`/Terraform handle configuration where appropriate.

### Description
- Reworked `scripts/deploy-stack.sh` to stop generating `scripts/.state/*` and `terraform/generated.auto.tfvars`, and pass redirect URIs to Terraform via `-var` instead of writing a file.
- Removed logic that created KV namespaces and rewrote `wrangler.toml`; the script now validates that `PAYMENT_STORE` IDs are set in each app's `wrangler.toml` and fails early if placeholders remain.
- Simplified Worker URL extraction and removed the Python patching/restore flow, replacing Python-based edits with robust `awk` parsing for `wrangler.toml` KV bindings.
- Rewrote `scripts/cleanup-stack.sh` to be idempotent and state-free: it runs `terraform destroy`, deletes secrets and Workers, and deletes KV namespaces only when a real `PAYMENT_STORE` ID is present in `wrangler.toml`.
- Small usability fixes: use `pnpm install --frozen-lockfile`, clearer error messages, and consistent parsing of `wrangler deploy` output for the workers.dev URL.

### Testing
- Ran a shell syntax check with `bash -n scripts/deploy-stack.sh scripts/cleanup-stack.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c53dd19d8832b8881b910d21db9e3)